### PR TITLE
RSS handling

### DIFF
--- a/cc_corpus/content_conversion.py
+++ b/cc_corpus/content_conversion.py
@@ -66,6 +66,6 @@ def convert(record: WARCRecord):
     else:
         chunks = [text]
 
-    return header, [chunk for chunk in chunks if chunk and chunk.strip()]
+    return header, [chunk for chunk in chunks if not is_empty(chunk)]
     # return header, [str(BeautifulSoup(chunk)) for chunk in chunks
     #                 if chunk and chunk.strip()]

--- a/cc_corpus/content_conversion.py
+++ b/cc_corpus/content_conversion.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+The functions in this module convert the content in WARC files into regular
+HTML that boilerplate removers can consume based on their content types.
+"""
+
+from typing import Any, Optional
+
+import atoma
+from bs4 import BeautifulSoup
+from warc import WARCRecord
+
+
+def compose_chunk(*pieces: Optional[Any]) -> str:
+    """
+    Composes _pieces_ into a single text chunk, adding each only if they are
+    not ``None``.
+    """
+    return '\n\n'.join(f'<p>{piece}</p>' for piece in pieces if piece)
+
+
+def convert(record: WARCRecord):
+    content_type = record["WARC-Identified-Payload-Type"]
+    header, text = record.payload.read().split(b'\r\n\r\n', maxsplit=1)
+    chunks = []
+    if content_type == 'application/rss+xml':
+        feed = atoma.parse_rss_bytes(text)
+        if (chunk := compose_chunk(feed.title, feed.description)):
+            chunks.append(chunk)
+        for item in feed.items:
+            if (chunk := compose_chunk(item.title, item.description)):
+                chunks.append(chunk)
+    elif content_type == 'application/atom+xml':
+        feed = atoma.parse_atom_bytes(text)
+        for e in feed.entries:
+            feed_chunks = []
+            if e.title is not None:
+                # TODO JusText always filters this out, fix that...
+                feed_chunks.append(f'<p>{e.title.value}</p>')
+            if e.summary is not None:
+                feed_chunks.append(e.summary.value)
+            if e.content is not None:
+                feed_chunks.append(e.content.value)
+            chunks.append('\n\n'.join(feed_chunks))
+    else:
+        chunks.append(text)
+    return header, [str(BeautifulSoup(chunk)) for chunk in chunks]

--- a/cc_corpus/content_conversion.py
+++ b/cc_corpus/content_conversion.py
@@ -64,7 +64,7 @@ def convert(record: WARCRecord):
     elif content_type == 'application/rss+xml':
         chunks = convert_rss(text)
     else:
-        chunks.append(text)
+        chunks = [text]
 
     return header, [chunk for chunk in chunks if chunk and chunk.strip()]
     # return header, [str(BeautifulSoup(chunk)) for chunk in chunks

--- a/cc_corpus/content_conversion.py
+++ b/cc_corpus/content_conversion.py
@@ -46,4 +46,5 @@ def convert(record: WARCRecord):
             chunks.append('\n\n'.join(feed_chunks))
     else:
         chunks.append(text)
-    return header, [str(BeautifulSoup(chunk)) for chunk in chunks]
+    return header, [str(BeautifulSoup(chunk)) for chunk in chunks
+                    if chunk and chunk.strip()]

--- a/cc_corpus/content_conversion.py
+++ b/cc_corpus/content_conversion.py
@@ -6,44 +6,63 @@ The functions in this module convert the content in WARC files into regular
 HTML that boilerplate removers can consume based on their content types.
 """
 
-from typing import Any, Optional
-
 import atoma
 # from bs4 import BeautifulSoup
 from warc import WARCRecord
 
+from cc_corpus.utils import is_empty
 
-def compose_chunk(*pieces: Optional[Any]) -> str:
-    """
-    Composes _pieces_ into a single text chunk, adding each only if they are
-    not ``None``.
-    """
-    return '\n\n'.join(f'<p>{piece}</p>' for piece in pieces if piece)
+
+def convert_atom(text: bytes) -> list[str]:
+    """Converts an atom feed."""
+    def not_empty(elem) -> bool:
+        return elem is not None and not is_empty(elem.value)
+
+    feed = atoma.parse_atom_bytes(text)
+    chunks = []
+    for e in feed.entries:
+        # Only keep an item if it contains meaningful text
+        if not_empty(e.summary) and not_empty(e.content):
+            item_chunks = []
+            if not_empty(e.title):
+                # TODO JusText always filters this out, fix that...
+                item_chunks.append(f'<p>{e.title.value}</p>')
+            if not_empty(e.summary):
+                item_chunks.append(e.summary.value)
+            if not_empty(e.content):
+                item_chunks.append(e.content.value)
+            chunks.append('\n\n'.join(item_chunks))
+    return chunks
+
+
+def convert_rss(text: bytes) -> list[str]:
+    """Converts an RSS feed."""
+    def compose_chunk(*pieces) -> str:
+        """
+        Composes _pieces_ into a single text chunk, adding each only if they
+        are not ``None``.
+        """
+        return '\n\n'.join(f'<p>{piece}</p>' for piece in pieces if piece)
+
+    feed = atoma.parse_rss_bytes(text)
+    # Only keep an item if it contains meaningful text
+    chunks = ['\n\n'.join(
+        compose_chunk(item.title, item.description) for item in feed.items
+        if not is_empty(item.title) and not is_empty(item.description)
+    )]
+    if chunks or not is_empty(feed.description):
+        return [compose_chunk(feed.title, feed.description)] + chunks
+    else:
+        return []
 
 
 def convert(record: WARCRecord):
     content_type = record["WARC-Identified-Payload-Type"]
     header, text = record.payload.read().split(b'\r\n\r\n', maxsplit=1)
-    chunks = []
-    if content_type == 'application/rss+xml':
-        feed = atoma.parse_rss_bytes(text)
-        if (chunk := compose_chunk(feed.title, feed.description)):
-            chunks.append(chunk)
-        for item in feed.items:
-            if (chunk := compose_chunk(item.title, item.description)):
-                chunks.append(chunk)
-    elif content_type == 'application/atom+xml':
-        feed = atoma.parse_atom_bytes(text)
-        for e in feed.entries:
-            feed_chunks = []
-            if e.title is not None:
-                # TODO JusText always filters this out, fix that...
-                feed_chunks.append(f'<p>{e.title.value}</p>')
-            if e.summary is not None:
-                feed_chunks.append(e.summary.value)
-            if e.content is not None:
-                feed_chunks.append(e.content.value)
-            chunks.append('\n\n'.join(feed_chunks))
+    if content_type == 'application/atom+xml':
+        chunks = convert_atom(text)
+    elif content_type == 'application/rss+xml':
+        chunks = convert_rss(text)
     else:
         chunks.append(text)
 

--- a/cc_corpus/content_conversion.py
+++ b/cc_corpus/content_conversion.py
@@ -9,7 +9,7 @@ HTML that boilerplate removers can consume based on their content types.
 from typing import Any, Optional
 
 import atoma
-from bs4 import BeautifulSoup
+# from bs4 import BeautifulSoup
 from warc import WARCRecord
 
 
@@ -46,5 +46,7 @@ def convert(record: WARCRecord):
             chunks.append('\n\n'.join(feed_chunks))
     else:
         chunks.append(text)
-    return header, [str(BeautifulSoup(chunk)) for chunk in chunks
-                    if chunk and chunk.strip()]
+
+    return header, [chunk for chunk in chunks if chunk and chunk.strip()]
+    # return header, [str(BeautifulSoup(chunk)) for chunk in chunks
+    #                 if chunk and chunk.strip()]

--- a/cc_corpus/utils.py
+++ b/cc_corpus/utils.py
@@ -341,5 +341,13 @@ def consume(iterator: Iterator):
     collections.deque(iterator, maxlen=0)
 
 
+def is_empty(s: Union[bytes, str]) -> bool:
+    """
+    Checks if _s_ is empty; i.e. it is either ``None`` or contains only
+    whitespaces.
+    """
+    return s is None or not s.strip()
+
+
 # tqdm to print the progress bar to stdout. This helps keeping the log clean.
 otqdm = partial(tqdm, file=sys.stdout)

--- a/scripts/deduplicate_index_urls.py
+++ b/scripts/deduplicate_index_urls.py
@@ -62,6 +62,7 @@ def read_urls(urls_file: str, url_fn: UrlFn) -> UrlSet:
     document deduplication will take care of this.
     """
     with openall(urls_file) as inf:
+        logging.info(f'Loading urls from {urls_file}...')
         urls = set()
         no_urls = 0
         for no_urls, url in enumerate(map(str.strip, inf), start=1):
@@ -130,7 +131,7 @@ CollectStats = Stats.create(
 def uniq_record(url: Url, record: IndexRecord, uniqs: UrlIndexDict,
                 keep: str) -> str:
     """
-    Uniq's a record. Returns whether the record is uniq (not in uniqs), or is
+    Uniq's a record. Returns whether the record is unique (not in uniqs), or is
     the representative of its URL (i.e. it is the latest / biggest). Returns
     a string that describes what happened to the URL (``reject`` / ``new``
     / ``overwrite``).

--- a/scripts/lsh.py
+++ b/scripts/lsh.py
@@ -292,8 +292,8 @@ def other_main(args):
         len(batch_prefixes), args.input_dir))
 
     batches_to_subtract = find_all_batches(args.cross_dir)
-    logging.info('Found a total of {} batches in {}to deduplicate against.'.format(
-        len(batches_to_subtract), args.cross_dir))
+    logging.info(f'Found a total of {len(batches_to_subtract)} batches in '
+                 f'{args.cross_dir} to deduplicate against.')
 
     with ProcessPoolExecutor(max_workers=args.processes) as executor:
         f = partial(deduplicate_other, batches_to_subtract=batches_to_subtract,

--- a/scripts/remove_boilerplate.py
+++ b/scripts/remove_boilerplate.py
@@ -110,7 +110,6 @@ class IndexWarcReader:
         # And the HTML header and text as well. jusText can handle bytes
         # header, text = warc.payload.read().split(b'\r\n\r\n', maxsplit=1)
         header, chunks = convert(warc)
-        logging.debug(f'chunks: {chunks}')
         try:
             paragraphs = chain.from_iterable(
                 self.remover.remove(chunk, index.url) for chunk in chunks

--- a/scripts/remove_boilerplate.py
+++ b/scripts/remove_boilerplate.py
@@ -115,11 +115,11 @@ class IndexWarcReader:
             return
 
         # Escape paragraph for parsable XML
-        text_removed = '\n\n'.join(
-            '<p>\n{0}\n</p>'.format(xml.sax.saxutils.escape(paragraph))
+        extracted_text = '\n\n'.join(
+            f'<p>\n{xml.sax.saxutils.escape(paragraph)}\n</p>'
             for paragraph in paragraphs
         )
-        if len(text_removed) == 0:
+        if len(extracted_text) == 0:
             logging.info(f'Nothing\'s left of {index.url} '
                          'after boilerplate removal')
             return
@@ -131,7 +131,7 @@ class IndexWarcReader:
                   index.domain, index.index, index.url, index.warc,
                   index.offset, index.length, index.status, index.mime,
                   bio.getvalue().decode('utf-8').strip(),
-                  header.decode('utf-8').strip(), text_removed),
+                  header.decode('utf-8').strip(), extracted_text),
               file=self.outf)
 
         if index_id % 1000 == 0:

--- a/scripts/wc.py
+++ b/scripts/wc.py
@@ -16,7 +16,7 @@ from multiprocessing_logging import install_mp_handler
 import warc
 
 from cc_corpus.corpus import parse_file
-from cc_corpus.utils import collect_inputs
+from cc_corpus.utils import collect_inputs, otqdm
 
 
 def parse_arguments():
@@ -101,6 +101,10 @@ def count_warc_file(filename, docs, ps, words, chars):
     return num_docs, 0, 0, num_chars
 
 
+def tqdm_info(inputs):
+    return ', '.join(inputs[:3]) + ('...' if len(inputs) >= 3 else '')
+
+
 def main():
     args = parse_arguments()
 
@@ -119,7 +123,8 @@ def main():
         f = partial(count_fn, docs=args.documents, ps=args.paragraphs,
                     words=args.words, chars=args.characters)
         stats = [0, 0, 0, 0]
-        for sub_stats in p.map(f, files):
+        tqdm_msg = f'Counting {tqdm_info(args.inputs)}'
+        for sub_stats in p.imap_unordered(f, otqdm(files, tqdm_msg)):
             for i in range(len(stats)):
                 stats[i] += sub_stats[i]
 


### PR DESCRIPTION
Parsing RSS and Atom feeds as regular (X)HTML results in gibberish (escaped HTML / JS code) getting into the corpus. This PR adds a content type-based preprocessing step to the boilerplate removal process to properly parse feeds. In the future, the new step can be utilized to tackle other problematic content types as well.