### PR TITLE
Deduplication-related bugfixes + enhancements 

### DIFF
--- a/scripts/lsh.py
+++ b/scripts/lsh.py
@@ -145,13 +145,18 @@ def read_batch_to_lsh(
     return lsh
 
 
+def check_batch(batch: Path):
+    """Checks if there is a DONE file in the given batch."""
+    return (batch / done_file).is_file()
+
+
 def check_and_wait_for_batch(batch: Path):
     """
-    Checks if there is a DONE.txt in the given batch.
+    Checks if there is a DONE in the given batch.
     If not, then it waits until there is.
     """
-    logging.debug(f'Checking batch {batch} whether it\'s done or not')
-    while not (batch / done_file).is_file():
+    logging.debug(f'Waiting until batch {batch} is done...')
+    while not check_batch(batch):
         sleep(5)
     logging.debug(f'We waited on batch {batch} and now it\'s done!')
 
@@ -170,7 +175,7 @@ def deduplicate_other(main_batch: Path,
     Warning: only works for full documents at this point!
     """
     main_base = main_batch.name
-    logging.info(f'Processing input batch {main_base}...')
+    logging.info(f'Processing input batch {main_batch}...')
     main_batch_data = read_batch_to_memory(main_batch)
     initial_len = len(main_batch_data)
 
@@ -183,8 +188,8 @@ def deduplicate_other(main_batch: Path,
         lsh = read_batch_to_lsh(batch, threshold, permutations)
         main_batch_data = [x for x in main_batch_data if not lsh.query(x[1])]
         logging.info(
-            f'Cross-deduplicated input batch {main_base} with cross batch '
-            f'{batch.name}: {initial_batch_len} -> {len(main_batch_data)} '
+            f'Cross-deduplicated input batch {main_batch} with cross batch '
+            f'{batch}: {initial_batch_len} -> {len(main_batch_data)} '
             'documents'
         )
     # We print the documents left:

--- a/scripts/lsh.py
+++ b/scripts/lsh.py
@@ -223,7 +223,7 @@ def deduplicate_other(main_batch: Path,
             f.write('This file flags this batch done for multiprocess'
                     ' deduplication')
 
-    logging.info(f'Processed input batch {main_base}; '
+    logging.info(f'Processed input batch {main_batch}; '
                  f'kept {len(main_batch_data)} out of {initial_len} documents')
     return len(main_batch_data), initial_len
 

--- a/scripts/minhash.py
+++ b/scripts/minhash.py
@@ -123,7 +123,6 @@ def main():
         os.makedirs(args.output_dir)
 
     files = sorted(collect_inputs(args.inputs))
-    print(f'Number of processes: {args.processes}')
     logging.info('Found a total of {} input files.'.format(len(files)))
 
     unit_str = 'paragraph' if args.unit == 'p' else 'document'

--- a/scripts/minhash.py
+++ b/scripts/minhash.py
@@ -126,6 +126,8 @@ def main():
     print(f'Number of processes: {args.processes}')
     logging.info('Found a total of {} input files.'.format(len(files)))
 
+    unit_str = 'paragraph' if args.unit == 'p' else 'document'
+    input_str = str(args.inputs[0]) + (' (etc)' if len(args.inputs) > 1 else '')
     with closing(
         BatchWriter(args.batch_size, args.output_dir, args.zeroes)
     ) as writer:
@@ -133,7 +135,8 @@ def main():
             minhash_fun = minhash_ps if args.unit == 'p' else minhash_docs
             f = partial(minhash_fun, permutations=args.permutations, n=args.n)
             for input_file, results in otqdm(
-                pool.imap_unordered(f, files), 'Minhashing...', total=len(files)
+                pool.imap_unordered(f, files),
+                f'Minhashing {unit_str}s from {input_str}...', total=len(files)
             ):
                 logging.debug('Got results for {}: {}'.format(
                     input_file, len(results['minhash'])))
@@ -143,7 +146,7 @@ def main():
             pool.join()
         logging.info('Done.')
 
-    logging.info('Hashed in total {} paragraphs.'.format(writer.total_written))
+    logging.info(f'Hashed in total {writer.total_written} {unit_str}s.')
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def readme():
 
 
 setup(name='commoncrawl-downloader',
-      version='1.11.5',
+      version='1.11.6',
       description='A Python package for retrieving a list of urls and '
                   'specific files in bulk from Common Crawl, as well as '
                   'for processing the downloaded files.',


### PR DESCRIPTION
Bugfix:
  - batch deduplication was broken because `multiproc_coordination` was not set

Enhancements:
  - log messages to contain the full name of the batch (inc. directory name)
  - `check_batch` function
  - better output and tqdm in `minhash.py`